### PR TITLE
fix: use colon instead of double underscore when reading settings override value from IConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Basically postman for the ASB emulator!
 
 ### Wiring up in Aspire
 
-1.  Add the `AspireAsbEmulatorUi.Hosting` package to your AppHost project.
+1.  Add the [`AJP.Aspire.Hosting.AsbEmulatorUi`](https://www.nuget.org/packages/AJP.Aspire.Hosting.AsbEmulatorUi/) package to your AppHost project.
 2.  Use one of the approaches below to add the UI resource.
 
 #### Using `WithUi()` (recommended)

--- a/src/AspireAsbEmulatorUi.App/Services/SettingsService.cs
+++ b/src/AspireAsbEmulatorUi.App/Services/SettingsService.cs
@@ -26,8 +26,7 @@ public class SettingsService
         _settings = new Settings();
 
         // First, try to load from settings override (passed from Aspire AppHost)
-        var settingsOverride = _configuration["AsbEmulatorUi__SettingsOverride"]
-                              ?? _configuration["ASBEMULATORUI__SETTINGSOVERRIDE"];
+        var settingsOverride = _configuration["AsbEmulatorUi:SettingsOverride"];
 
         if (!string.IsNullOrWhiteSpace(settingsOverride))
         {

--- a/tests/AspireAsbEmulatorUi.App.Tests/SettingsServiceTests.cs
+++ b/tests/AspireAsbEmulatorUi.App.Tests/SettingsServiceTests.cs
@@ -1,0 +1,53 @@
+﻿using AspireAsbEmulatorUi.App.Services;
+using AspireAsbEmulatorUi.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.JSInterop;
+using NSubstitute;
+using System.Text.Json;
+
+namespace AspireAsbEmulatorUi.App.Tests;
+
+public class SettingsServiceTests
+{
+    [Test]
+    public async Task SettingsService_Initializes_WithSettingsOverride()
+    {
+        // Create unique settings
+        var settings = new Settings()
+        {
+            CannedMessages = new()
+            {
+                ["test-topic"] = new()
+                {
+                    ["MyTestMessage"] = new()
+                    {
+                        Body = """
+                        {
+                            "Id": 1,
+                            "Name": "Test Name",
+                            "IsActive": true
+                        }
+                        """
+                    }
+                }
+            }
+        };
+
+        // Set environment variable
+        var serializedSettings = JsonSerializer.Serialize(settings);
+        Environment.SetEnvironmentVariable("AsbEmulatorUi__SettingsOverride", serializedSettings);
+
+        // Build configuration object
+        var config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+
+        var settingsService = new SettingsService(
+            config,
+            Substitute.For<IJSRuntime>(),
+            NullLogger<SettingsService>.Instance);
+
+        var result = settingsService.GetSettings();
+
+        await Assert.That(result).IsEquivalentTo(settings);
+    }
+}


### PR DESCRIPTION
Resolvoes #5 

I also removed the line in `SettingsService` where it would fall back to the all-caps version of the environment variable name since `IConfiguration` is not case-sensitive.

Note: I'm not sure why the PR is showing that I've modified the README.md file; I have not, it matches what is already in the main branch.